### PR TITLE
Fix reflection warning

### DIFF
--- a/src/latacora/wernicke/core.clj
+++ b/src/latacora/wernicke/core.clj
@@ -71,7 +71,7 @@
   [parsed group-config ^java.util.regex.Matcher matcher]
   (reduce
    (fn [parsed [group-name behavior]]
-     (let [actual (.group matcher group-name)]
+     (let [actual (.group matcher ^String group-name)]
        (case behavior
          ::keep (set-group-value parsed group-name actual)
          ::keep-length (set-group-length parsed group-name (count actual)))))


### PR DESCRIPTION
This fixes a reflection warning. While the type of `Matcher` was correctly resolved, the argument was not: `Matcher` (in JDK9+) has a group method that takes an int, which is the traditional sequential group method, and another that takes a String. We want the one with a String, and GraalVM couldn't figure that out statically.