### PR TITLE
changed long-decimal-re to be 12 chars

### DIFF
--- a/src/latacora/wernicke/core.clj
+++ b/src/latacora/wernicke/core.clj
@@ -151,7 +151,10 @@
     (regex-rule* p/base16-re-uppercase
                  {::group-config
                   {"s" {::behavior ::keep-length}}})
-    (regex-rule* p/long-decimal-re)
+    (regex-rule* p/long-decimal-re
+                 {::group-config
+                  {"s" {::behavior ::keep-length}}})
+    (regex-rule* p/decimal-re)
     (regex-rule* p/long-alphanumeric-re
                  {::group-config
                   {"s" {::behavior ::keep-length}}})]})

--- a/src/latacora/wernicke/patterns.clj
+++ b/src/latacora/wernicke/patterns.clj
@@ -37,8 +37,11 @@
 (def ipv4-re
   (re-pattern (str/join "\\." (repeat 4 ipv4-octet-re))))
 
-(def long-decimal-re
+(def decimal-re
   #"[0-9]{5,}")
+
+(def long-decimal-re
+   #"(?<s>[0-9]{12,})")
 
 (def long-alphanumeric-re
   "A regex for long (24+) alphanumeric strings."
@@ -53,7 +56,7 @@
   (let [partition "aws"
         service "(?<service>[a-z0-9\\-]{2,20})"
         region "(?<region>((us|eu)-(west|east)(-\\d)?)|\\*)?"
-        account (str "(?<account>" long-decimal-re "|\\*)?")
+        account (str "(?<account>" decimal-re "|\\*)?")
         resource "[A-Za-z0-9\\-\\._ */:]+"]
     (re-pattern (str/join ":" ["arn" partition service region account resource]))))
 

--- a/test/latacora/wernicke/core_test.clj
+++ b/test/latacora/wernicke/core_test.clj
@@ -72,6 +72,9 @@
                          wp/ipv4-re]
 
                         ["123456789" ;; ec2 requester-id, owner-id...
+                         wp/decimal-re]
+
+                        ["123456789012" ;; aws account ids...
                          wp/long-decimal-re]
 
                         ["ip-10-0-0-1.ec2.internal"


### PR DESCRIPTION
This change was done in order to retain the length of aws account ids
the old long-decimal-re was changed to just decimal-re where 5 digits will not
retain length but anything over 12 that falls into long-decimal-re will.